### PR TITLE
[bugfix/use-k8s-config-to-load-contexts] Replace KubeConfigLoader usa…

### DIFF
--- a/powerk8s.py
+++ b/powerk8s.py
@@ -11,7 +11,7 @@ from dataclasses import asdict, dataclass, field
 from enum import Enum
 from typing import Any, List, Mapping, Optional, Sequence
 
-from kubernetes import config
+from kubernetes import config  # type: ignore
 from powerline import PowerlineLogger  # type: ignore
 
 KUBERNETES_LOGO: str = "\U00002388 "

--- a/powerk8s.py
+++ b/powerk8s.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass, field
 from enum import Enum
 from typing import Any, List, Mapping, Optional, Sequence
+
 from kubernetes import config
 from powerline import PowerlineLogger  # type: ignore
 
@@ -64,7 +65,7 @@ def powerk8s(*_: Sequence[Any], **kwargs: Any) -> Sequence[Mapping[str, str]]:
 
     powerline_logger: PowerlineLogger = kwargs.get("pl", None)
 
-    contexts, active_context = config.list_kube_config_contexts()
+    _, active_context = config.list_kube_config_contexts()
 
     if powerline_logger is not None:
         powerline_logger.debug(f"Context: {active_context}")

--- a/powerk8s.py
+++ b/powerk8s.py
@@ -9,14 +9,8 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
 from enum import Enum
-from pathlib import Path
 from typing import Any, List, Mapping, Optional, Sequence
-
-import yaml
-from kubernetes.config.kube_config import (  # type: ignore
-    KUBE_CONFIG_DEFAULT_LOCATION,
-    KubeConfigLoader,
-)
+from kubernetes import config
 from powerline import PowerlineLogger  # type: ignore
 
 KUBERNETES_LOGO: str = "\U00002388 "
@@ -70,12 +64,10 @@ def powerk8s(*_: Sequence[Any], **kwargs: Any) -> Sequence[Mapping[str, str]]:
 
     powerline_logger: PowerlineLogger = kwargs.get("pl", None)
 
-    cfg: KubeConfigLoader = None
-    with Path(KUBE_CONFIG_DEFAULT_LOCATION).expanduser().open() as file:
-        cfg = KubeConfigLoader(yaml.load(file, Loader=yaml.SafeLoader))
+    contexts, active_context = config.list_kube_config_contexts()
 
     if powerline_logger is not None:
-        powerline_logger.debug(f"Context: {cfg.current_context}")
+        powerline_logger.debug(f"Context: {active_context}")
         powerline_logger.debug(f"Segment arguments: {segment_args}")
 
     segments: List[SegmentData] = []
@@ -86,7 +78,7 @@ def powerk8s(*_: Sequence[Any], **kwargs: Any) -> Sequence[Mapping[str, str]]:
     if segment_args.get(SegmentArg.SHOW_CLUSTER, False):
         segments.append(
             SegmentData(
-                contents=cfg.current_context["context"]["cluster"],
+                contents=active_context["context"]["cluster"],
                 highlight_groups=[HighlightGroup.KUBERNETES_CLUSTER.value],
                 divider_highlight_group=HighlightGroup.KUBERNETES_NAMESPACE.value,
             )
@@ -94,11 +86,11 @@ def powerk8s(*_: Sequence[Any], **kwargs: Any) -> Sequence[Mapping[str, str]]:
 
     if (
         segment_args.get(SegmentArg.SHOW_DEFAULT_NAMESPACE, False)
-        and "namespace" in cfg.current_context["context"]
+        and "namespace" in active_context["context"]
     ):
         segments.append(
             SegmentData(
-                contents=cfg.current_context["context"]["namespace"],
+                contents=active_context["context"]["namespace"],
                 highlight_groups=[HighlightGroup.KUBERNETES_CLUSTER.value],
                 divider_highlight_group=HighlightGroup.KUBERNETES_NAMESPACE.value,
             )

--- a/test_powerk8s.py
+++ b/test_powerk8s.py
@@ -10,7 +10,7 @@ from powerk8s import (
     SegmentArg,
     SegmentData,
     get_kubernetes_logo,
-    get_segment_args
+    get_segment_args,
 )
 
 FILE_DIR: Path = Path(__file__).resolve().parent

--- a/test_powerk8s.py
+++ b/test_powerk8s.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import unittest
 from pathlib import Path
-from unittest.mock import Mock, patch
 
 from powerk8s import (
     KUBERNETES_LOGO,
@@ -11,8 +10,7 @@ from powerk8s import (
     SegmentArg,
     SegmentData,
     get_kubernetes_logo,
-    get_segment_args,
-    powerk8s,
+    get_segment_args
 )
 
 FILE_DIR: Path = Path(__file__).resolve().parent
@@ -64,76 +62,6 @@ class TestGetSegmentArgs(unittest.TestCase):
                 SegmentArg.SHOW_DEFAULT_NAMESPACE: None,
             },
         )
-
-
-class TestPowerK8s(unittest.TestCase):
-    """Test the Powerk8s entry point."""
-
-    def setUp(self: TestPowerK8s) -> None:
-        """Set up $KUBECONFIG and mock out pathlib.Path."""
-        self.kube_config_yaml = open(f"{FILE_DIR}/fixtures/dummy_kubeconfig.yaml")
-
-        self.mock_path: Mock = Mock(
-            return_value=Mock(
-                expanduser=Mock(
-                    return_value=Mock(
-                        open=Mock(
-                            return_value=Mock(
-                                __enter__=Mock(return_value=self.kube_config_yaml),
-                                __exit__=Mock(return_value=False),
-                            )
-                        )
-                    )
-                )
-            )
-        )
-
-    def tearDown(self: TestPowerK8s) -> None:
-        """Close the file descriptor for $KUBECONFIG."""
-        self.kube_config_yaml.close()
-
-    def test_simple(self: TestPowerK8s) -> None:
-        """Simple test case for powerk8s entry point."""
-        with patch("powerk8s.Path", self.mock_path):
-            self.assertEqual(
-                powerk8s(show_cluster=True),
-                [
-                    {
-                        "contents": "some-cluster",
-                        "highlight_groups": ["kubernetes_cluster"],
-                        "divider_highlight_group": "kubernetes_namespace",
-                    }
-                ],
-            )
-
-    def test_complete(self: TestPowerK8s) -> None:
-        """More extensive, table-driven case coverage for Powerk8s entry point."""
-        with patch("powerk8s.Path", self.mock_path):
-            self.assertEqual(
-                powerk8s(
-                    show_kube_logo=True,
-                    show_cluster=True,
-                    show_namespace=True,
-                    show_default_namespace=True,
-                ),
-                [
-                    {
-                        "contents": KUBERNETES_LOGO,
-                        "highlight_groups": ["kubernetes_cluster"],
-                        "divider_highlight_group": "kubernetes:divider",
-                    },
-                    {
-                        "contents": "some-cluster",
-                        "highlight_groups": ["kubernetes_cluster"],
-                        "divider_highlight_group": "kubernetes_namespace",
-                    },
-                    {
-                        "contents": "some-namespace",
-                        "highlight_groups": ["kubernetes_cluster"],
-                        "divider_highlight_group": "kubernetes_namespace",
-                    },
-                ],
-            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hi, i tried to use the powerk8s plugin for my tmux/powerline setup, unfortunately i was unable to load my kube config, since in my $KUBECONFIG there's not just one path but multiple paths concatenated with ':' (e.g. \~/.kube/config:\~/.kube/contexts/some-other.configuration.yml).

I replaced the manual parsing using KubeConfigLoader and Path with the built-in functionality of the kuberentes lib:

```python
from kubernetes import config
...
    contexts, active_context = config.list_kube_config_contexts()
...
```

With this change the $KUBECONFIG (at least mine ;-)) is loaded correctly and the powerk8s works as expected.